### PR TITLE
Fix ```"is not" with a literal.``` in python 3.8

### DIFF
--- a/download_gdrive.py
+++ b/download_gdrive.py
@@ -47,7 +47,7 @@ def download_file_from_google_drive(id, destination):
 
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) is not 3:
+    if len(sys.argv) != 3:
         print("Usage: python google_drive.py drive_file_id destination_file_path")
     else:
         # TAKE ID FROM SHAREABLE LINK


### PR DESCRIPTION
Fix ```SyntaxWarning: "is not" with a literal. Did you mean "!="?``` in python 3.8